### PR TITLE
Remove dependency on the MainWindow

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -83,7 +83,6 @@ namespace Ryujinx.Ava
 
         private Thread _mainThread;
 
-        private KeyboardHotkeyState _prevHotkeyState;
 
         private IRenderer _renderer;
         private readonly Thread _renderingThread;

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -25,9 +25,9 @@ using System.Threading.Tasks;
 
 namespace Ryujinx.Ava
 {
-    internal class Program
+    public class Program
     {
-        public static double WindowScaleFactor { get; private set; }
+        public static double WindowScaleFactor { get; set; }
         public static string Version           { get; private set; }
         public static string ConfigurationPath { get; private set; }
         public static bool   PreviewerDetached { get; private set; }

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 
 namespace Ryujinx.Ava
 {
-    public class Program
+    internal class Program
     {
         public static string Version           { get; private set; }
         public static string ConfigurationPath { get; private set; }

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -27,7 +27,6 @@ namespace Ryujinx.Ava
 {
     public class Program
     {
-        public static double WindowScaleFactor { get; set; }
         public static string Version           { get; private set; }
         public static string ConfigurationPath { get; private set; }
         public static bool   PreviewerDetached { get; private set; }
@@ -99,10 +98,6 @@ namespace Ryujinx.Ava
                     launchPathArg = arg;
                 }
             }
-
-            // Make process DPI aware for proper window sizing on high-res screens.
-            ForceDpiAware.Windows();
-            WindowScaleFactor = ForceDpiAware.GetWindowScaleFactor();
 
             // Delete backup files after updating.
             Task.Run(Updater.CleanupUpdate);

--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -21,7 +21,7 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
         <None Update="Config.json">
-            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
     <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">

--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
@@ -21,7 +21,7 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
         <None Update="Config.json">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
         </None>
     </ItemGroup>
     <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
@@ -34,77 +34,77 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <None Remove="Assets\Images\star.png"/>
-        <None Remove="Assets\Styles\BaseDark.xaml"/>
-        <None Remove="Assets\Styles\BaseLight.xaml"/>
+        <None Remove="Assets\Images\star.png" />
+        <None Remove="Assets\Styles\BaseDark.xaml" />
+        <None Remove="Assets\Styles\BaseLight.xaml" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Assets\Images\star.png"/>
+        <EmbeddedResource Include="Assets\Images\star.png" />
         <AvaloniaResource Include="Assets\Styles\BaseLight.xaml">
             <Generator>MSBuild:Compile</Generator>
         </AvaloniaResource>
         <AvaloniaResource Include="Assets\Styles\BaseDark.xaml">
             <Generator>MSBuild:Compile</Generator>
         </AvaloniaResource>
-        <AvaloniaResource Include="Assets\Styles\Styles.xaml"/>
+        <AvaloniaResource Include="Assets\Styles\Styles.xaml" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.10"/>
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.10"/>
-        <PackageReference Include="Avalonia.Svg" Version="0.10.10"/>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="0.10.10"/>
-        <PackageReference Include="AvaloniaColorPicker" Version="1.1.0"/>
-        <PackageReference Include="DiscordRichPresence" Version="1.0.175"/>
-        <PackageReference Include="DynamicData" Version="7.4.3"/>
-        <PackageReference Include="FluentAvaloniaUI" Version="1.1.5"/>
-        <PackageReference Include="IX.Observable" Version="0.7.3"/>
-        <PackageReference Include="Crc32.NET" Version="1.2.0"/>
-        <PackageReference Include="jp2masa.Avalonia.Flexbox" Version="0.2.0"/>
-        <PackageReference Include="Ryujinx.Audio.OpenAL.Dependencies" Version="1.21.0.1" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'"/>
-        <PackageReference Include="OpenTK" Version="4.6.3"/>
-        <PackageReference Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="4.4.0-build9" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'"/>
-        <PackageReference Include="SharpZipLib" Version="1.3.2"/>
-        <PackageReference Include="PInvoke.User32" Version="0.7.104"/>
-        <PackageReference Include="Avalonia" Version="0.10.10"/>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.10"/>
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.10"/>
-        <PackageReference Include="Silk.NET.Vulkan" Version="2.2.0"/>
-        <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.2.0"/>
-        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2"/>
-        <PackageReference Include="SPB" Version="0.0.3-build15"/>
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="0.10.10" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.10" />
+        <PackageReference Include="Avalonia.Svg" Version="0.10.10" />
+        <PackageReference Include="Avalonia.Svg.Skia" Version="0.10.10" />
+        <PackageReference Include="AvaloniaColorPicker" Version="1.1.0" />
+        <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
+        <PackageReference Include="DynamicData" Version="7.4.3" />
+        <PackageReference Include="FluentAvaloniaUI" Version="1.1.5" />
+        <PackageReference Include="IX.Observable" Version="0.7.3" />
+        <PackageReference Include="Crc32.NET" Version="1.2.0" />
+        <PackageReference Include="jp2masa.Avalonia.Flexbox" Version="0.2.0" />
+        <PackageReference Include="Ryujinx.Audio.OpenAL.Dependencies" Version="1.21.0.1" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
+        <PackageReference Include="OpenTK" Version="4.6.3" />
+        <PackageReference Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="4.4.0-build9" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
+        <PackageReference Include="SharpZipLib" Version="1.3.2" />
+        <PackageReference Include="PInvoke.User32" Version="0.7.104" />
+        <PackageReference Include="Avalonia" Version="0.10.10" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.10" />
+        <PackageReference Include="Silk.NET.Vulkan" Version="2.2.0" />
+        <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.2.0" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
+        <PackageReference Include="SPB" Version="0.0.3-build15" />
     </ItemGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Assets\Images\Controller_JoyConLeft.svg"/>
-        <EmbeddedResource Include="Assets\Images\Controller_JoyConPair.svg"/>
-        <EmbeddedResource Include="Assets\Images\Controller_JoyConRight.svg"/>
-        <EmbeddedResource Include="Assets\Images\Controller_ProCon.svg"/>
-        <EmbeddedResource Include="Assets\Images\Icon_NCA.png"/>
-        <EmbeddedResource Include="Assets\Images\Icon_NRO.png"/>
-        <EmbeddedResource Include="Assets\Images\Icon_NSO.png"/>
-        <EmbeddedResource Include="Assets\Images\Icon_NSP.png"/>
-        <EmbeddedResource Include="Assets\Images\Icon_XCI.png"/>
-        <EmbeddedResource Include="Assets\Images\Logo_Amiibo.png"/>
-        <EmbeddedResource Include="Assets\Images\Logo_Discord.png"/>
-        <EmbeddedResource Include="Assets\Images\Logo_GitHub.png"/>
-        <EmbeddedResource Include="Assets\Images\Logo_Patreon.png"/>
-        <EmbeddedResource Include="Assets\Images\Logo_Ryujinx.png"/>
-        <EmbeddedResource Include="Assets\Images\Logo_Twitter.png"/>
-        <EmbeddedResource Include="Assets\Locales\en_US.json"/>
-        <EmbeddedResource Include="Assets\Locales\fr_FR.json"/>
-        <EmbeddedResource Include="Assets\Locales\pt_BR.json"/>
-        <EmbeddedResource Include="Assets\Styles\Styles.xaml"/>
+        <EmbeddedResource Include="Assets\Images\Controller_JoyConLeft.svg" />
+        <EmbeddedResource Include="Assets\Images\Controller_JoyConPair.svg" />
+        <EmbeddedResource Include="Assets\Images\Controller_JoyConRight.svg" />
+        <EmbeddedResource Include="Assets\Images\Controller_ProCon.svg" />
+        <EmbeddedResource Include="Assets\Images\Icon_NCA.png" />
+        <EmbeddedResource Include="Assets\Images\Icon_NRO.png" />
+        <EmbeddedResource Include="Assets\Images\Icon_NSO.png" />
+        <EmbeddedResource Include="Assets\Images\Icon_NSP.png" />
+        <EmbeddedResource Include="Assets\Images\Icon_XCI.png" />
+        <EmbeddedResource Include="Assets\Images\Logo_Amiibo.png" />
+        <EmbeddedResource Include="Assets\Images\Logo_Discord.png" />
+        <EmbeddedResource Include="Assets\Images\Logo_GitHub.png" />
+        <EmbeddedResource Include="Assets\Images\Logo_Patreon.png" />
+        <EmbeddedResource Include="Assets\Images\Logo_Ryujinx.png" />
+        <EmbeddedResource Include="Assets\Images\Logo_Twitter.png" />
+        <EmbeddedResource Include="Assets\Locales\en_US.json" />
+        <EmbeddedResource Include="Assets\Locales\fr_FR.json" />
+        <EmbeddedResource Include="Assets\Locales\pt_BR.json" />
+        <EmbeddedResource Include="Assets\Styles\Styles.xaml" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Ryujinx.Audio.Backends.SDL2\Ryujinx.Audio.Backends.SDL2.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Input\Ryujinx.Input.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Input.SDL2\Ryujinx.Input.SDL2.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Audio.Backends.OpenAL\Ryujinx.Audio.Backends.OpenAL.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Audio.Backends.SoundIo\Ryujinx.Audio.Backends.SoundIo.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj"/>
-        <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj"/>
-        <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Graphics.OpenGL\Ryujinx.Graphics.OpenGL.csproj"/>
-        <ProjectReference Include="..\Ryujinx.Graphics.Gpu\Ryujinx.Graphics.Gpu.csproj"/>
+        <ProjectReference Include="..\Ryujinx.Audio.Backends.SDL2\Ryujinx.Audio.Backends.SDL2.csproj" />
+        <ProjectReference Include="..\Ryujinx.Input\Ryujinx.Input.csproj" />
+        <ProjectReference Include="..\Ryujinx.Input.SDL2\Ryujinx.Input.SDL2.csproj" />
+        <ProjectReference Include="..\Ryujinx.Audio.Backends.OpenAL\Ryujinx.Audio.Backends.OpenAL.csproj" />
+        <ProjectReference Include="..\Ryujinx.Audio.Backends.SoundIo\Ryujinx.Audio.Backends.SoundIo.csproj" />
+        <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
+        <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj" />
+        <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj" />
+        <ProjectReference Include="..\Ryujinx.Graphics.OpenGL\Ryujinx.Graphics.OpenGL.csproj" />
+        <ProjectReference Include="..\Ryujinx.Graphics.Gpu\Ryujinx.Graphics.Gpu.csproj" />
     </ItemGroup>
     <ItemGroup>
         <AvaloniaXaml Update="Ui\Windows\ControllerSettingsWindow.axaml">

--- a/Ryujinx.Ava/Ui/Applet/AvaHostUiHandler.cs
+++ b/Ryujinx.Ava/Ui/Applet/AvaHostUiHandler.cs
@@ -13,7 +13,7 @@ using System.Threading;
 
 namespace Ryujinx.Ava.Ui.Applet
 {
-    internal class AvaHostUiHandler : IHostUiHandler
+    public class AvaHostUiHandler : IHostUiHandler
     {
         private readonly MainWindow _parent;
 

--- a/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
@@ -18,6 +18,7 @@ using Ryujinx.Ava.Ui.Windows;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Configuration;
+using Ryujinx.Graphics.Gpu;
 using Ryujinx.HLE;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.FileSystem.Content;
@@ -805,10 +806,10 @@ namespace Ryujinx.Ava.Ui.ViewModels
             }
         }
 
-        public void HandleShaderProgress(Switch emulationContext)
+        public void HandleShaderProgress(GpuContext gpuContext)
         {
-            emulationContext.Gpu.ShaderCacheStateChanged -= ProgressHandler;
-            emulationContext.Gpu.ShaderCacheStateChanged += ProgressHandler;
+            gpuContext.ShaderCacheStateChanged -= ProgressHandler;
+            gpuContext.ShaderCacheStateChanged += ProgressHandler;
         }
 
         private bool Filter(object arg)
@@ -934,27 +935,27 @@ namespace Ryujinx.Ava.Ui.ViewModels
             }
         }
 
-        public async void TakeScreenshot()
+        public void TakeScreenshot()
         {
             _owner.AppHost.ScreenshotRequested = true;
         }
 
-        public async void HideUi()
+        public void HideUi()
         {
             ShowMenuAndStatusBar = false;
         }
 
-        public async void SetListMode()
+        public void SetListMode()
         {
             ViewMode = ViewMode.List;
         }
 
-        public async void SetGridMode()
+        public void SetGridMode()
         {
             ViewMode = ViewMode.Grid;
         }
 
-        public async void OpenMiiApplet()
+        public void OpenMiiApplet()
         {
             string contentPath = _owner.ContentManager.GetInstalledContentPath(0x0100000000001009, StorageId.NandSystem, NcaContentType.Program);
 

--- a/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Data.Common;
 using System.Globalization;
 using System.IO;
 using System.Reactive.Linq;
@@ -251,10 +252,10 @@ namespace Ryujinx.Ava.Ui.ViewModels
                 {
                     case ViewMode.List:
                         return _owner.GameList.SelectedItem as ApplicationData;
-                        break;
+                        
                     case ViewMode.Grid:
                         return _owner.GameGrid.SelectedApplication;
-                        break;
+                        
                     default:
                         return null;
                 }
@@ -1070,8 +1071,8 @@ namespace Ryujinx.Ava.Ui.ViewModels
                 }
             }
             catch (Exception ex)
-            {
-                
+{
+                Logger.Error?.Print(LogClass.Application, ex.Message);
             }
         }
 
@@ -1415,7 +1416,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
                         }
                         catch (Exception ex)
                         {
-                            Dispatcher.UIThread.InvokeAsync(async delegate
+                            Dispatcher.UIThread.InvokeAsync(() =>
                             {
                                 waitingDialog.Close();
 

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS
 {
     using JsonHelper = Common.Utilities.JsonHelper;
 
-    public class ApplicationLoader
+    public class ApplicationLoader : IApplicationLoaderTitleInformation
     {
         // Binaries from exefs are loaded into mem in this order. Do not change.
         internal static readonly string[] ExeFsPrefixes =

--- a/Ryujinx.HLE/HOS/IApplicationLoaderTitleInformation.cs
+++ b/Ryujinx.HLE/HOS/IApplicationLoaderTitleInformation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ryujinx.HLE.HOS
+{
+    public interface IApplicationLoaderTitleInformation
+    {
+        ulong TitleId { get; }
+        bool TitleIs64Bit { get; }
+        string TitleIdText { get; }
+        string DisplayVersion { get; }
+        string TitleName { get; }
+    }
+}


### PR DESCRIPTION
To make the render component independent of the UI, all references to MainWindow must be removed. This makes it possible to embed the render component in any window. This would also make it much easier to change the UI without affecting the render control. In addition, the hotkeys now work like fullscreen even if no game has been started.