### PR TITLE
Base widget consistency and volume tweaks

### DIFF
--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -728,12 +728,14 @@
                         Height="12"
                         BorderBrush="Gray" />
                     <ui:ToggleSplitButton
-                        Margin="5,0,5,0"
-                        Padding="5,0,5,0"
+                        Margin="-2,0,-3,0"
+                        Padding="5,0,0,5"
                         Name="VolumeStatus"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         IsVisible="{Binding !ShowLoadProgress}"
+                        BorderBrush="{DynamicResource ThemeContentBackgroundColor}"
+                        Background="{DynamicResource ThemeContentBackgroundColor}"
                         IsChecked="{Binding VolumeMuted}"
                         Content="{Binding VolumeStatusText}">
                         <ui:ToggleSplitButton.Flyout>

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -698,6 +698,7 @@
                     <TextBlock
                         Margin="5,0,5,0"
                         Name="DockedStatus"
+                        IsVisible="{Binding !ShowLoadProgress}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         PointerReleased="DockedStatus_PointerReleased"
@@ -713,6 +714,7 @@
                     <TextBlock
                         Margin="5,0,5,0"
                         Name="AspectRatioStatus"
+                        IsVisible="{Binding !ShowLoadProgress}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         PointerReleased="AspectRatioStatus_PointerReleased"
@@ -759,6 +761,7 @@
                         BorderBrush="Gray" />
                     <TextBlock
                         Margin="5,0,5,0"
+                        IsVisible="{Binding !ShowLoadProgress}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         Text="{Binding GameStatusText}"
@@ -772,6 +775,7 @@
                         BorderBrush="Gray" />
                     <TextBlock
                         Margin="5,0,5,0"
+                        IsVisible="{Binding !ShowLoadProgress}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         Text="{Binding FifoStatusText}"
@@ -785,6 +789,7 @@
                         BorderBrush="Gray" />
                     <TextBlock
                         Margin="5,0,5,0"
+                        IsVisible="{Binding !ShowLoadProgress}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         Text="{Binding GpuStatusText}"


### PR DESCRIPTION
- Remove the final few bottom widgets from the loading screen
- Blend the volume button into the UI and compact it efficiently
New: 
![image](https://user-images.githubusercontent.com/44103205/152663718-88c5a4b1-7bf9-4532-b3ad-cfcf3ae26bde.png)
Old:
![image](https://user-images.githubusercontent.com/44103205/152663728-2760445e-b6f8-4ac7-b3c9-a6d60c522f9d.png)
