### PR TITLE
Expose hotkeys configuration on the UI

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -537,5 +537,12 @@
   "UpdaterDownloading": "Downloading Update...",
   "Game": "Game",
   "Docked": "Docked",
-  "Handheld": "Handheld"
+  "Handheld": "Handheld",
+  "SettingsTabHotkeys": "Keyboard Hotkeys",
+  "SettingsTabHotkeysHotkeys": "Keyboard Hotkeys",
+  "SettingsTabHotkeysToggleVsyncHotkey": "Toggle VSync:",
+  "SettingsTabHotkeysScreenshotHotkey": "Screenshot:",
+  "SettingsTabHotkeysShowUiHotkey": "Show UI:",
+  "SettingsTabHotkeysPauseHotkey": "Pause:",
+  "SettingsTabHotkeysToggleMuteHotkey":  "Mute:"
 }

--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -544,5 +544,5 @@
   "SettingsTabHotkeysScreenshotHotkey": "Screenshot:",
   "SettingsTabHotkeysShowUiHotkey": "Show UI:",
   "SettingsTabHotkeysPauseHotkey": "Pause:",
-  "SettingsTabHotkeysToggleMuteHotkey":  "Mute:"
+  "SettingsTabHotkeysToggleMuteHotkey": "Mute:"
 }

--- a/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
@@ -86,9 +86,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
 
             if (Program.PreviewerDetached)
             {
-                ShowUiKey = KeyGesture.Parse(ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUi.ToString());
-                ScreenshotKey = KeyGesture.Parse(ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot.ToString());
-                PauseKey = KeyGesture.Parse(ConfigurationState.Instance.Hid.Hotkeys.Value.Pause.ToString());
+                LoadConfigurableHotKeys();
 
                 Volume = ConfigurationState.Instance.System.AudioVolume;
             }
@@ -834,6 +832,13 @@ namespace Ryujinx.Ava.Ui.ViewModels
             }
         }
 
+        public void LoadConfigurableHotKeys()
+        {
+            ShowUiKey = KeyGesture.Parse(ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUi.ToString());
+            ScreenshotKey = KeyGesture.Parse(ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot.ToString());
+            PauseKey = KeyGesture.Parse(ConfigurationState.Instance.Hid.Hotkeys.Value.Pause.ToString());
+        }
+
         public async void TakeScreenshot()
         {
             _owner.AppHost.ScreenshotRequested = true;
@@ -933,6 +938,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
             _owner.SettingsWindow = new(_owner.VirtualFileSystem, _owner.ContentManager);
 
             await _owner.SettingsWindow.ShowDialog(_owner);
+            LoadConfigurableHotKeys();
         }
 
         public async void ManageProfiles()

--- a/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
@@ -6,13 +6,16 @@ using Ryujinx.Audio.Backends.OpenAL;
 using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Audio.Backends.SoundIo;
 using Ryujinx.Ava.Common.Locale;
+using Ryujinx.Ava.Input;
 using Ryujinx.Ava.Ui.Controls;
 using Ryujinx.Ava.Ui.Windows;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS.Services.Time.TimeZone;
+using Ryujinx.Input;
 using Ryujinx.Ui.Common.Configuration;
 using Ryujinx.Ui.Common.Configuration.System;
 using System;
@@ -158,6 +161,21 @@ namespace Ryujinx.Ava.Ui.ViewModels
 
         public AvaloniaList<string> GameDirectories { get; set; }
 
+        private KeyboardHotkeys _keyboardHotkeys;
+
+        public KeyboardHotkeys KeyboardHotkeys
+        {
+            get => _keyboardHotkeys;
+            set
+            {
+                _keyboardHotkeys = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public IGamepadDriver AvaloniaKeyboardDriver { get; }
+
         public SettingsViewModel(VirtualFileSystem virtualFileSystem, ContentManager contentManager, StyleableWindow owner) : this()
         {
             _virtualFileSystem = virtualFileSystem;
@@ -166,6 +184,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
             if (Program.PreviewerDetached)
             {
                 LoadTimeZones();
+                AvaloniaKeyboardDriver = new AvaloniaKeyboardDriver(owner);
             }
         }
 
@@ -301,6 +320,8 @@ namespace Ryujinx.Ava.Ui.ViewModels
             DateOffset = dateTimeOffset.Date;
             TimeOffset = dateTimeOffset.TimeOfDay;
 
+            KeyboardHotkeys = config.Hid.Hotkeys.Value;
+
             _previousVolumeLevel = Volume;
         }
 
@@ -375,6 +396,8 @@ namespace Ryujinx.Ava.Ui.ViewModels
 
                 Logger.Info?.Print(LogClass.Application, $"AudioBackend toggled to: {audioBackend}");
             }
+
+            config.Hid.Hotkeys.Value = KeyboardHotkeys;
 
             config.ToFileFormat().SaveConfig(Program.ConfigurationPath);
 

--- a/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml
@@ -22,6 +22,9 @@
     <Design.DataContext>
         <viewModels:SettingsViewModel />
     </Design.DataContext>
+	<Window.Resources>
+		<controls:KeyValueConverter x:Key="Key" />
+	</Window.Resources>
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinWidth="600">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -201,6 +204,57 @@
                     </StackPanel>
                 </Border>
             </ScrollViewer>
+			<ScrollViewer Name="HotkeysPage"
+                          HorizontalAlignment="Stretch"
+                          VerticalAlignment="Stretch"
+                          HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+				<Border>
+					<StackPanel Margin="10,5" Spacing="5" Orientation="Vertical">
+						<TextBlock FontWeight="Bold" Text="{locale:Locale SettingsTabHotkeysHotkeys}" />
+						<StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="{locale:Locale SettingsTabHotkeysToggleVsyncHotkey}" Width="230" />
+                            <ToggleButton Width="90" Height="27" Margin="2" Checked="Button_Checked" Unchecked="Button_Unchecked">
+                                <TextBlock
+                                    Text="{Binding KeyboardHotkeys.ToggleVsync, Mode=TwoWay, Converter={StaticResource Key}}"
+                                    TextAlignment="Center" />
+                            </ToggleButton>
+                        </StackPanel>
+						<StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="{locale:Locale SettingsTabHotkeysScreenshotHotkey}" Width="230" />
+                            <ToggleButton Width="90" Height="27" Margin="2" Checked="Button_Checked" Unchecked="Button_Unchecked">
+                                <TextBlock
+                                    Text="{Binding KeyboardHotkeys.Screenshot, Mode=TwoWay, Converter={StaticResource Key}}"
+                                    TextAlignment="Center" />
+                            </ToggleButton>
+                        </StackPanel>
+						<StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="{locale:Locale SettingsTabHotkeysShowUiHotkey}" Width="230" />
+                            <ToggleButton Width="90" Height="27" Margin="2" Checked="Button_Checked" Unchecked="Button_Unchecked">
+                                <TextBlock
+                                    Text="{Binding KeyboardHotkeys.ShowUi, Mode=TwoWay, Converter={StaticResource Key}}"
+                                    TextAlignment="Center" />
+                            </ToggleButton>
+                        </StackPanel>
+						<StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="{locale:Locale SettingsTabHotkeysPauseHotkey}" Width="230" />
+                            <ToggleButton Width="90" Height="27" Margin="2" Checked="Button_Checked" Unchecked="Button_Unchecked">
+                                <TextBlock
+                                    Text="{Binding KeyboardHotkeys.Pause, Mode=TwoWay, Converter={StaticResource Key}}"
+                                    TextAlignment="Center" />
+                            </ToggleButton>
+                        </StackPanel>
+					    <StackPanel Orientation="Horizontal" Margin="10,0,0,0">
+                            <TextBlock VerticalAlignment="Center" Text="{locale:Locale SettingsTabHotkeysToggleMuteHotkey}" Width="230" />
+                            <ToggleButton Width="90" Height="27" Margin="2" Checked="Button_Checked" Unchecked="Button_Unchecked">
+                                <TextBlock
+                                    Text="{Binding KeyboardHotkeys.ToggleMute, Mode=TwoWay, Converter={StaticResource Key}}"
+                                    TextAlignment="Center" />
+                            </ToggleButton>
+                        </StackPanel>
+					</StackPanel>
+				</Border>
+			</ScrollViewer>
             <ScrollViewer Name="SystemPage"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
@@ -208,7 +262,7 @@
                           VerticalScrollBarVisibility="Auto">
                 <Border>
                     <StackPanel
-                        Margin="10, 5"
+                        Margin="10,5"
                         HorizontalAlignment="Stretch"
                         Orientation="Vertical">
                         <TextBlock FontWeight="Bold" Text="{locale:Locale SettingsTabSystemCore}" />
@@ -347,7 +401,7 @@
                                 Spacing="20">
                                 <TextBlock VerticalAlignment="Center"
                                            Text="{locale:Locale SettingsTabSystemSystemTime}"
-                                           ToolTip.Tip="{locale:Locale TimeTooltip}" 
+                                           ToolTip.Tip="{locale:Locale TimeTooltip}"
                                            Width="230"/>
                                 <DatePicker VerticalAlignment="Center" SelectedDate="{Binding DateOffset}"
                                             ToolTip.Tip="{locale:Locale TimeTooltip}"
@@ -834,6 +888,10 @@
                     Content="{locale:Locale SettingsTabInput}"
                     Tag="InputPage"
                     Icon="Games" />
+				<ui:NavigationViewItem
+                    Content="{locale:Locale SettingsTabHotkeys}"
+                    Tag="HotkeysPage"
+                    Icon="Keyboard" />
                 <ui:NavigationViewItem
                     Content="{locale:Locale SettingsTabSystem}"
                     Tag="SystemPage"

--- a/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
+++ b/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.Common.Configuration.Hid
 {
-    public struct KeyboardHotkeys
+    public class KeyboardHotkeys
     {
         public Key ToggleVsync { get; set; }
         public Key Screenshot { get; set; }


### PR DESCRIPTION
This is just exposing the hotkey configuration on the UI. I didn't really add any new configuration entry here. The key binding logic was copied from the controller binding user control (btw, if you could change it to share the binding code it would be nice, since its mostly the same).

I added a `LoadConfigurableHotKeys` method to allow the "key gestures" on the main window to be reloaded. It is called on initialization and also after the settings dialog is closed (since they might have been modified then). Couldn't find a better place to put it, ideally I think it would be called from `SaveSettings` but then it would require passing a reference of the main window.

Should probably be tested too since I only tested it a bit yesterday.

![image](https://user-images.githubusercontent.com/5624669/166248832-33789f6e-4891-4672-b410-2c0cfb3c6d28.png)

Possible future work:
- Expose remaining hotkeys that are currently not configurable (like Escape to quit emulation).
- Allow "key gestures" (Control, Alt and Shift combos).
- Allow binding controller buttons.